### PR TITLE
Add personal notes for favorite stations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ site/data/summary.json
 site/app.js
 !/site/
 site/*
+!/site/note.mjs
 !/site/data/
 site/data/*
 !/site/data/station-occupancy/

--- a/site/app.js
+++ b/site/app.js
@@ -30,6 +30,12 @@ import {
   parseStoredRatings,
   serializeStoredRatings,
 } from "./rating.mjs";
+import {
+  getUserNote,
+  normalizeNote,
+  parseStoredNotes,
+  serializeStoredNotes,
+} from "./note.mjs";
 
 /**
  * woladen.de - Modern Frontend Logic
@@ -40,9 +46,12 @@ const MAX_DISPLAY_POWER_KW = 400;
 const DEFAULT_MIN_POWER_KW = 50;
 const RATINGS_STORAGE_KEY = "woladen_ratings_v1";
 const RATING_CLIENT_STORAGE_KEY = "woladen_rating_client_v1";
+const NOTES_STORAGE_KEY = "woladen_notes_v1";
 const RATING_SUMMARY_REFRESH_MS = 60000;
 const RATING_API_TIMEOUT_MS = 3500;
 const LIST_VIEW_MAX_STATIONS = 20;
+const FAVORITE_SORT_DISTANCE = "distance";
+const FAVORITE_SORT_RATING = "rating";
 const LIVE_SUMMARY_REFRESH_MS = 15000;
 const LIVE_API_TIMEOUT_MS = 3500;
 const LIVE_DETAIL_TIMEOUT_MS = 4000;
@@ -657,6 +666,8 @@ const state = {
   filtered: [], // Currently filtered features
   favorites: new Set(), // Set of station_ids
   ratings: new Map(), // station_id -> 1-5 rating stored locally
+  notes: new Map(), // station_id -> personal note stored locally
+  favoriteSort: FAVORITE_SORT_DISTANCE,
   ratingClientId: "",
   ratingSummariesByStationId: new Map(),
   ratingSummaryFetchedAtByStationId: new Map(),
@@ -724,6 +735,9 @@ const els = {
     chargers: document.getElementById("charger-list"),
     favorites: document.getElementById("favorites-list"),
   },
+  favorites: {
+    sort: document.getElementById("favorites-sort"),
+  },
   filter: {
     trigger: document.getElementById("filter-trigger"),
     label: document.getElementById("filter-label"),
@@ -752,6 +766,8 @@ const els = {
     ratingBadge: document.getElementById("detail-rating-badge"),
     ratingStatus: document.getElementById("detail-rating-status"),
     ratingStars: document.getElementById("detail-rating-stars"),
+    noteInput: document.getElementById("detail-note-input"),
+    noteStatus: document.getElementById("detail-note-status"),
     amenityTitle: document.getElementById("detail-amenities-title"),
     amenityList: document.getElementById("detail-amenities-list"),
     detailsSection: document.getElementById("detail-details-section"),
@@ -791,6 +807,7 @@ const VIEW_IDS = new Set(["view-list", "view-map", "view-favorites", "view-info"
 async function init() {
   loadFavorites();
   loadRatings();
+  loadNotes();
   initMap();
   initNavigation();
   syncViewWithRequestedHash();
@@ -817,6 +834,8 @@ async function init() {
 
   els.detail.favBtn.addEventListener("click", toggleDetailFavorite);
   els.detail.ratingStars.addEventListener("click", handleRatingClick);
+  els.detail.noteInput.addEventListener("input", handleDetailNoteInput);
+  els.favorites.sort.addEventListener("change", handleFavoriteSortChange);
 
   // Load Data
   await loadData();
@@ -1542,6 +1561,10 @@ function getRatingForProps(props) {
   return getUserRating(state.ratings, getStationIdFromProps(props));
 }
 
+function getNoteForProps(props) {
+  return getUserNote(state.notes, getStationIdFromProps(props));
+}
+
 function getRatingSummaryForProps(props) {
   const stationId = getStationIdFromProps(props);
   if (!stationId) {
@@ -1614,6 +1637,9 @@ function applyFilters() {
   if (els.views.list.classList.contains("active")) {
     renderList();
   }
+  if (els.views.favorites.classList.contains("active")) {
+    renderFavorites();
+  }
 }
 
 /* --- LIST RENDERING --- */
@@ -1678,19 +1704,17 @@ function renderFavorites() {
     state.favorites.has(f.properties.station_id),
   );
 
-  if (state.userPos) {
-    favFeatures.sort((a, b) => getDistance(a) - getDistance(b));
-  }
+  favFeatures.sort(compareFavoriteFeatures);
 
   favFeatures.forEach((feature) => {
-    const card = createStationCard(feature);
+    const card = createStationCard(feature, { showNote: true });
     container.appendChild(card);
   });
   requestLiveSummariesForFeatures(favFeatures);
   requestRatingSummariesForFeatures(favFeatures);
 }
 
-function createStationCard(feature) {
+function createStationCard(feature, options = {}) {
   const p = feature.properties;
   const div = document.createElement("div");
   div.className = "station-card";
@@ -1721,6 +1745,14 @@ function createStationCard(feature) {
     ? `<div class="card-badge-line card-badge-line-amenities">${amenityBadges}</div>`
     : "";
   const ratingBadge = renderRatingBadge(getRatingDisplayForProps(p));
+  const metrics = `${ratingBadge}${distance ? `<span class="card-distance">${distance}</span>` : ""}`;
+  const metricsMarkup = metrics
+    ? `<div class="card-metrics">${metrics}</div>`
+    : "";
+  const note = options.showNote ? getNoteForProps(p) : "";
+  const noteMarkup = note
+    ? `<div class="card-note"><span class="card-note-label">Anmerkung</span><p>${escapeHtml(note)}</p></div>`
+    : "";
 
   const markerColor = getMarkerColor(p);
   
@@ -1729,9 +1761,8 @@ function createStationCard(feature) {
       <div class="card-title-row">
         <span class="amenity-dot" style="background-color: ${markerColor}"></span>
         <h3 class="card-title">${escapeHtml(p.operator || "Unbekannt")}</h3>
-        ${ratingBadge}
       </div>
-      ${distance ? `<span class="card-distance">${distance}</span>` : ""}
+      ${metricsMarkup}
     </div>
     <div class="card-meta">
       ${escapeHtml(p.city || "")}<br>
@@ -1740,10 +1771,59 @@ function createStationCard(feature) {
     <div class="card-badges">
       ${dynamicLine}${amenityLine}
     </div>
+    ${noteMarkup}
   `;
 
   div.addEventListener("click", () => openDetail(feature));
   return div;
+}
+
+function compareFavoriteFeatures(a, b) {
+  if (state.favoriteSort === FAVORITE_SORT_RATING) {
+    return compareFavoriteFeaturesByRating(a, b);
+  }
+
+  return compareFavoriteFeaturesByDistance(a, b);
+}
+
+function compareFavoriteFeaturesByRating(a, b) {
+  const ratingDiff = getFavoriteSortRating(b.properties) - getFavoriteSortRating(a.properties);
+  if (ratingDiff !== 0) {
+    return ratingDiff;
+  }
+  return compareFavoriteFeaturesByName(a, b);
+}
+
+function compareFavoriteFeaturesByDistance(a, b) {
+  if (state.userPos) {
+    const distanceDiff = getDistance(a) - getDistance(b);
+    if (distanceDiff !== 0) {
+      return distanceDiff;
+    }
+  }
+  return compareFavoriteFeaturesByName(a, b);
+}
+
+function compareFavoriteFeaturesByName(a, b) {
+  const leftName = String(a.properties?.operator || "");
+  const rightName = String(b.properties?.operator || "");
+  const nameDiff = leftName.localeCompare(rightName, "de");
+  if (nameDiff !== 0) {
+    return nameDiff;
+  }
+  const leftId = getStationIdFromProps(a.properties);
+  const rightId = getStationIdFromProps(b.properties);
+  return leftId.localeCompare(rightId);
+}
+
+function getFavoriteSortRating(props) {
+  const userRating = getRatingForProps(props);
+  if (userRating > 0) {
+    return userRating;
+  }
+  const displayRating = getRatingDisplayForProps(props);
+  const rating = Number(displayRating?.value || 0);
+  return Number.isFinite(rating) ? rating : 0;
 }
 
 function getDisplayedMaxPowerKw(props) {
@@ -2017,6 +2097,16 @@ function updateDetailRating(props) {
   });
 }
 
+function updateDetailNote(props) {
+  const stationId = getStationIdFromProps(props);
+  const note = getNoteForProps(props);
+  els.detail.noteInput.value = note;
+  els.detail.noteInput.disabled = !stationId;
+  els.detail.noteStatus.textContent = note
+    ? "Anmerkung lokal gespeichert"
+    : "Nur auf diesem Gerät gespeichert";
+}
+
 function populateDetailContent(feature, liveDetail = null) {
   const p = feature.properties;
   const powerDisplay = `${Math.round(getDisplayedMaxPowerKw(p))} kW max / ${formatChargingPointCount(p)}`;
@@ -2052,6 +2142,7 @@ function populateDetailContent(feature, liveDetail = null) {
   els.detail.amenityTitle.textContent = formatAmenityCount(p.amenities_total);
 
   updateDetailRating(p);
+  updateDetailNote(p);
   renderDetailAmenities(p);
   renderDetailStaticInfo(p);
   renderDetailLiveState(feature, liveDetail);
@@ -2373,6 +2464,38 @@ async function handleRatingClick(event) {
   }
 }
 
+function handleDetailNoteInput(event) {
+  if (!currentDetailFeature) {
+    return;
+  }
+  const stationId = getStationIdFromProps(currentDetailFeature.properties);
+  if (!stationId) {
+    return;
+  }
+
+  const note = normalizeNote(event.target.value);
+  if (note) {
+    state.notes.set(stationId, note);
+    els.detail.noteStatus.textContent = "Anmerkung lokal gespeichert";
+  } else {
+    state.notes.delete(stationId);
+    els.detail.noteStatus.textContent = "Nur auf diesem Gerät gespeichert";
+  }
+  saveNotes();
+
+  if (els.views.favorites.classList.contains("active")) {
+    renderFavorites();
+  }
+}
+
+function handleFavoriteSortChange(event) {
+  state.favoriteSort = event.target.value === FAVORITE_SORT_RATING
+    ? FAVORITE_SORT_RATING
+    : FAVORITE_SORT_DISTANCE;
+  els.favorites.sort.value = state.favoriteSort;
+  renderFavorites();
+}
+
 /* --- UTILS --- */
 function escapeHtml(str) {
   if (!str) return "";
@@ -2674,6 +2797,15 @@ function loadRatings() {
   }
 }
 
+function loadNotes() {
+  try {
+    state.notes = parseStoredNotes(localStorage.getItem(NOTES_STORAGE_KEY));
+  } catch (e) {
+    console.error("Error loading notes", e);
+    state.notes = new Map();
+  }
+}
+
 function createRatingClientId() {
   if (window.crypto?.randomUUID) {
     return window.crypto.randomUUID();
@@ -2717,6 +2849,14 @@ function saveRatings() {
     localStorage.setItem(RATINGS_STORAGE_KEY, serializeStoredRatings(state.ratings));
   } catch (e) {
     console.error("Error saving ratings", e);
+  }
+}
+
+function saveNotes() {
+  try {
+    localStorage.setItem(NOTES_STORAGE_KEY, serializeStoredNotes(state.notes));
+  } catch (e) {
+    console.error("Error saving notes", e);
   }
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -84,7 +84,7 @@
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""
     />
-    <link rel="stylesheet" href="./styles.css?v=20260503-shared-ratings" />
+    <link rel="stylesheet" href="./styles.css?v=20260510-notes-sort" />
   </head>
   <body>
     <div id="app" class="app-shell">
@@ -151,6 +151,15 @@
         <div id="view-favorites" class="view hidden">
           <div class="view-header" data-nosnippet>
             <h2>Favoriten</h2>
+            <div class="header-actions">
+              <label class="sort-control" for="favorites-sort">
+                <span>Sortieren</span>
+                <select id="favorites-sort">
+                  <option value="distance">Entfernung</option>
+                  <option value="rating">Sterne</option>
+                </select>
+              </label>
+            </div>
           </div>
           <div id="favorites-list" class="list-container">
             <div class="empty-state" data-nosnippet>
@@ -535,6 +544,17 @@
               </div>
             </div>
 
+            <label class="detail-note" for="detail-note-input" data-nosnippet>
+              <span class="detail-note-label">Persönliche Anmerkung</span>
+              <textarea
+                id="detail-note-input"
+                rows="3"
+                maxlength="600"
+                placeholder="z. B. gut beleuchtet, enger Parkplatz, Bäckerei um die Ecke"
+              ></textarea>
+              <span id="detail-note-status" class="detail-note-status">Nur auf diesem Gerät gespeichert</span>
+            </label>
+
             <div class="detail-actions">
               <a
                 id="btn-nav-google"
@@ -681,6 +701,6 @@
       crossorigin=""
     ></script>
     <script src="./app-install-promo.js"></script>
-    <script src="./app.js?v=20260503-shared-ratings" type="module"></script>
+    <script src="./app.js?v=20260510-notes-sort" type="module"></script>
   </body>
 </html>

--- a/site/note.mjs
+++ b/site/note.mjs
@@ -1,0 +1,52 @@
+const MAX_NOTE_LENGTH = 600;
+
+export function normalizeNote(value) {
+  const normalized = String(value || "")
+    .replace(/\r\n?/g, "\n")
+    .trim();
+  return normalized.slice(0, MAX_NOTE_LENGTH);
+}
+
+export function parseStoredNotes(raw) {
+  const notes = new Map();
+  if (!raw) {
+    return notes;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return notes;
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return notes;
+  }
+
+  Object.entries(payload).forEach(([stationId, value]) => {
+    const id = String(stationId || "").trim();
+    const note = normalizeNote(value);
+    if (id && note) {
+      notes.set(id, note);
+    }
+  });
+  return notes;
+}
+
+export function serializeStoredNotes(notes) {
+  const entries = Array.from(notes instanceof Map ? notes.entries() : [])
+    .map(([stationId, value]) => [String(stationId || "").trim(), normalizeNote(value)])
+    .filter(([stationId, note]) => stationId && note)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  return JSON.stringify(Object.fromEntries(entries));
+}
+
+export function getUserNote(notes, stationId) {
+  const id = String(stationId || "").trim();
+  if (!id || !(notes instanceof Map)) {
+    return "";
+  }
+  return normalizeNote(notes.get(id));
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -114,6 +114,28 @@ body {
   font-weight: 600;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.sort-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.sort-control select {
+  width: auto;
+  min-width: 8.5rem;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.9rem;
+}
+
 /* APP INSTALL PROMO */
 .app-install-promo {
   margin: 0 0 16px;
@@ -449,13 +471,15 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: 0.85rem;
   margin-bottom: 0.5rem;
 }
 
 .card-title-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -471,6 +495,7 @@ body {
   font-size: 1.05rem;
   margin: 0;
   min-width: 0;
+  line-height: 1.22;
 }
 
 .rating-badge {
@@ -489,12 +514,21 @@ body {
   flex-shrink: 0;
 }
 
+.card-metrics {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
 .card-distance {
   background: var(--color-primary-light);
   color: var(--color-primary-dark);
-  padding: 2px 8px;
+  padding: 0.15rem 0.45rem;
   border-radius: 4px;
-  font-size: 0.8rem;
+  font-size: 0.82rem;
+  line-height: 1.2;
   font-weight: 600;
   white-space: nowrap;
 }
@@ -513,6 +547,30 @@ body {
 
 .card-badges:empty {
   display: none;
+}
+
+.card-note {
+  display: grid;
+  gap: 0.25rem;
+  margin-top: 0.8rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.card-note-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+}
+
+.card-note p {
+  margin: 0;
+  color: var(--color-text-main);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .card-badge-line {
@@ -660,7 +718,8 @@ body {
 }
 
 select,
-input[type="search"] {
+input[type="search"],
+textarea {
   width: 100%;
   padding: 0.75rem;
   border: 1px solid var(--color-border);
@@ -669,6 +728,12 @@ input[type="search"] {
   font-size: 1rem;
   background: var(--color-bg);
   color: var(--color-text-main);
+}
+
+textarea {
+  min-height: 96px;
+  resize: vertical;
+  line-height: 1.45;
 }
 
 input[type="range"] {
@@ -933,6 +998,22 @@ input[type="search"]::placeholder {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface-dim);
+}
+
+.detail-note {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+}
+
+.detail-note-label {
+  font-weight: 700;
+  color: var(--color-text-main);
+}
+
+.detail-note-status {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
 }
 
 .detail-rating-copy {
@@ -1530,6 +1611,14 @@ input[type="search"]::placeholder {
 }
 
 @media (max-width: 420px) {
+  .sort-control > span {
+    display: none;
+  }
+
+  .sort-control select {
+    min-width: 7.5rem;
+  }
+
   .occupancy-history-chart {
     padding-inline: 0.65rem;
     overflow-x: auto;

--- a/web/app.js
+++ b/web/app.js
@@ -30,6 +30,12 @@ import {
   parseStoredRatings,
   serializeStoredRatings,
 } from "./rating.mjs";
+import {
+  getUserNote,
+  normalizeNote,
+  parseStoredNotes,
+  serializeStoredNotes,
+} from "./note.mjs";
 
 /**
  * woladen.de - Modern Frontend Logic
@@ -40,9 +46,12 @@ const MAX_DISPLAY_POWER_KW = 400;
 const DEFAULT_MIN_POWER_KW = 50;
 const RATINGS_STORAGE_KEY = "woladen_ratings_v1";
 const RATING_CLIENT_STORAGE_KEY = "woladen_rating_client_v1";
+const NOTES_STORAGE_KEY = "woladen_notes_v1";
 const RATING_SUMMARY_REFRESH_MS = 60000;
 const RATING_API_TIMEOUT_MS = 3500;
 const LIST_VIEW_MAX_STATIONS = 20;
+const FAVORITE_SORT_DISTANCE = "distance";
+const FAVORITE_SORT_RATING = "rating";
 const LIVE_SUMMARY_REFRESH_MS = 15000;
 const LIVE_API_TIMEOUT_MS = 3500;
 const LIVE_DETAIL_TIMEOUT_MS = 4000;
@@ -657,6 +666,8 @@ const state = {
   filtered: [], // Currently filtered features
   favorites: new Set(), // Set of station_ids
   ratings: new Map(), // station_id -> 1-5 rating stored locally
+  notes: new Map(), // station_id -> personal note stored locally
+  favoriteSort: FAVORITE_SORT_DISTANCE,
   ratingClientId: "",
   ratingSummariesByStationId: new Map(),
   ratingSummaryFetchedAtByStationId: new Map(),
@@ -724,6 +735,9 @@ const els = {
     chargers: document.getElementById("charger-list"),
     favorites: document.getElementById("favorites-list"),
   },
+  favorites: {
+    sort: document.getElementById("favorites-sort"),
+  },
   filter: {
     trigger: document.getElementById("filter-trigger"),
     label: document.getElementById("filter-label"),
@@ -752,6 +766,8 @@ const els = {
     ratingBadge: document.getElementById("detail-rating-badge"),
     ratingStatus: document.getElementById("detail-rating-status"),
     ratingStars: document.getElementById("detail-rating-stars"),
+    noteInput: document.getElementById("detail-note-input"),
+    noteStatus: document.getElementById("detail-note-status"),
     amenityTitle: document.getElementById("detail-amenities-title"),
     amenityList: document.getElementById("detail-amenities-list"),
     detailsSection: document.getElementById("detail-details-section"),
@@ -791,6 +807,7 @@ const VIEW_IDS = new Set(["view-list", "view-map", "view-favorites", "view-info"
 async function init() {
   loadFavorites();
   loadRatings();
+  loadNotes();
   initMap();
   initNavigation();
   syncViewWithRequestedHash();
@@ -817,6 +834,8 @@ async function init() {
 
   els.detail.favBtn.addEventListener("click", toggleDetailFavorite);
   els.detail.ratingStars.addEventListener("click", handleRatingClick);
+  els.detail.noteInput.addEventListener("input", handleDetailNoteInput);
+  els.favorites.sort.addEventListener("change", handleFavoriteSortChange);
 
   // Load Data
   await loadData();
@@ -1542,6 +1561,10 @@ function getRatingForProps(props) {
   return getUserRating(state.ratings, getStationIdFromProps(props));
 }
 
+function getNoteForProps(props) {
+  return getUserNote(state.notes, getStationIdFromProps(props));
+}
+
 function getRatingSummaryForProps(props) {
   const stationId = getStationIdFromProps(props);
   if (!stationId) {
@@ -1614,6 +1637,9 @@ function applyFilters() {
   if (els.views.list.classList.contains("active")) {
     renderList();
   }
+  if (els.views.favorites.classList.contains("active")) {
+    renderFavorites();
+  }
 }
 
 /* --- LIST RENDERING --- */
@@ -1678,19 +1704,17 @@ function renderFavorites() {
     state.favorites.has(f.properties.station_id),
   );
 
-  if (state.userPos) {
-    favFeatures.sort((a, b) => getDistance(a) - getDistance(b));
-  }
+  favFeatures.sort(compareFavoriteFeatures);
 
   favFeatures.forEach((feature) => {
-    const card = createStationCard(feature);
+    const card = createStationCard(feature, { showNote: true });
     container.appendChild(card);
   });
   requestLiveSummariesForFeatures(favFeatures);
   requestRatingSummariesForFeatures(favFeatures);
 }
 
-function createStationCard(feature) {
+function createStationCard(feature, options = {}) {
   const p = feature.properties;
   const div = document.createElement("div");
   div.className = "station-card";
@@ -1721,6 +1745,14 @@ function createStationCard(feature) {
     ? `<div class="card-badge-line card-badge-line-amenities">${amenityBadges}</div>`
     : "";
   const ratingBadge = renderRatingBadge(getRatingDisplayForProps(p));
+  const metrics = `${ratingBadge}${distance ? `<span class="card-distance">${distance}</span>` : ""}`;
+  const metricsMarkup = metrics
+    ? `<div class="card-metrics">${metrics}</div>`
+    : "";
+  const note = options.showNote ? getNoteForProps(p) : "";
+  const noteMarkup = note
+    ? `<div class="card-note"><span class="card-note-label">Anmerkung</span><p>${escapeHtml(note)}</p></div>`
+    : "";
 
   const markerColor = getMarkerColor(p);
   
@@ -1729,9 +1761,8 @@ function createStationCard(feature) {
       <div class="card-title-row">
         <span class="amenity-dot" style="background-color: ${markerColor}"></span>
         <h3 class="card-title">${escapeHtml(p.operator || "Unbekannt")}</h3>
-        ${ratingBadge}
       </div>
-      ${distance ? `<span class="card-distance">${distance}</span>` : ""}
+      ${metricsMarkup}
     </div>
     <div class="card-meta">
       ${escapeHtml(p.city || "")}<br>
@@ -1740,10 +1771,59 @@ function createStationCard(feature) {
     <div class="card-badges">
       ${dynamicLine}${amenityLine}
     </div>
+    ${noteMarkup}
   `;
 
   div.addEventListener("click", () => openDetail(feature));
   return div;
+}
+
+function compareFavoriteFeatures(a, b) {
+  if (state.favoriteSort === FAVORITE_SORT_RATING) {
+    return compareFavoriteFeaturesByRating(a, b);
+  }
+
+  return compareFavoriteFeaturesByDistance(a, b);
+}
+
+function compareFavoriteFeaturesByRating(a, b) {
+  const ratingDiff = getFavoriteSortRating(b.properties) - getFavoriteSortRating(a.properties);
+  if (ratingDiff !== 0) {
+    return ratingDiff;
+  }
+  return compareFavoriteFeaturesByName(a, b);
+}
+
+function compareFavoriteFeaturesByDistance(a, b) {
+  if (state.userPos) {
+    const distanceDiff = getDistance(a) - getDistance(b);
+    if (distanceDiff !== 0) {
+      return distanceDiff;
+    }
+  }
+  return compareFavoriteFeaturesByName(a, b);
+}
+
+function compareFavoriteFeaturesByName(a, b) {
+  const leftName = String(a.properties?.operator || "");
+  const rightName = String(b.properties?.operator || "");
+  const nameDiff = leftName.localeCompare(rightName, "de");
+  if (nameDiff !== 0) {
+    return nameDiff;
+  }
+  const leftId = getStationIdFromProps(a.properties);
+  const rightId = getStationIdFromProps(b.properties);
+  return leftId.localeCompare(rightId);
+}
+
+function getFavoriteSortRating(props) {
+  const userRating = getRatingForProps(props);
+  if (userRating > 0) {
+    return userRating;
+  }
+  const displayRating = getRatingDisplayForProps(props);
+  const rating = Number(displayRating?.value || 0);
+  return Number.isFinite(rating) ? rating : 0;
 }
 
 function getDisplayedMaxPowerKw(props) {
@@ -2017,6 +2097,16 @@ function updateDetailRating(props) {
   });
 }
 
+function updateDetailNote(props) {
+  const stationId = getStationIdFromProps(props);
+  const note = getNoteForProps(props);
+  els.detail.noteInput.value = note;
+  els.detail.noteInput.disabled = !stationId;
+  els.detail.noteStatus.textContent = note
+    ? "Anmerkung lokal gespeichert"
+    : "Nur auf diesem Gerät gespeichert";
+}
+
 function populateDetailContent(feature, liveDetail = null) {
   const p = feature.properties;
   const powerDisplay = `${Math.round(getDisplayedMaxPowerKw(p))} kW max / ${formatChargingPointCount(p)}`;
@@ -2052,6 +2142,7 @@ function populateDetailContent(feature, liveDetail = null) {
   els.detail.amenityTitle.textContent = formatAmenityCount(p.amenities_total);
 
   updateDetailRating(p);
+  updateDetailNote(p);
   renderDetailAmenities(p);
   renderDetailStaticInfo(p);
   renderDetailLiveState(feature, liveDetail);
@@ -2373,6 +2464,38 @@ async function handleRatingClick(event) {
   }
 }
 
+function handleDetailNoteInput(event) {
+  if (!currentDetailFeature) {
+    return;
+  }
+  const stationId = getStationIdFromProps(currentDetailFeature.properties);
+  if (!stationId) {
+    return;
+  }
+
+  const note = normalizeNote(event.target.value);
+  if (note) {
+    state.notes.set(stationId, note);
+    els.detail.noteStatus.textContent = "Anmerkung lokal gespeichert";
+  } else {
+    state.notes.delete(stationId);
+    els.detail.noteStatus.textContent = "Nur auf diesem Gerät gespeichert";
+  }
+  saveNotes();
+
+  if (els.views.favorites.classList.contains("active")) {
+    renderFavorites();
+  }
+}
+
+function handleFavoriteSortChange(event) {
+  state.favoriteSort = event.target.value === FAVORITE_SORT_RATING
+    ? FAVORITE_SORT_RATING
+    : FAVORITE_SORT_DISTANCE;
+  els.favorites.sort.value = state.favoriteSort;
+  renderFavorites();
+}
+
 /* --- UTILS --- */
 function escapeHtml(str) {
   if (!str) return "";
@@ -2674,6 +2797,15 @@ function loadRatings() {
   }
 }
 
+function loadNotes() {
+  try {
+    state.notes = parseStoredNotes(localStorage.getItem(NOTES_STORAGE_KEY));
+  } catch (e) {
+    console.error("Error loading notes", e);
+    state.notes = new Map();
+  }
+}
+
 function createRatingClientId() {
   if (window.crypto?.randomUUID) {
     return window.crypto.randomUUID();
@@ -2717,6 +2849,14 @@ function saveRatings() {
     localStorage.setItem(RATINGS_STORAGE_KEY, serializeStoredRatings(state.ratings));
   } catch (e) {
     console.error("Error saving ratings", e);
+  }
+}
+
+function saveNotes() {
+  try {
+    localStorage.setItem(NOTES_STORAGE_KEY, serializeStoredNotes(state.notes));
+  } catch (e) {
+    console.error("Error saving notes", e);
   }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -84,7 +84,7 @@
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""
     />
-    <link rel="stylesheet" href="./styles.css?v=20260503-shared-ratings" />
+    <link rel="stylesheet" href="./styles.css?v=20260510-notes-sort" />
   </head>
   <body>
     <div id="app" class="app-shell">
@@ -151,6 +151,15 @@
         <div id="view-favorites" class="view hidden">
           <div class="view-header" data-nosnippet>
             <h2>Favoriten</h2>
+            <div class="header-actions">
+              <label class="sort-control" for="favorites-sort">
+                <span>Sortieren</span>
+                <select id="favorites-sort">
+                  <option value="distance">Entfernung</option>
+                  <option value="rating">Sterne</option>
+                </select>
+              </label>
+            </div>
           </div>
           <div id="favorites-list" class="list-container">
             <div class="empty-state" data-nosnippet>
@@ -535,6 +544,17 @@
               </div>
             </div>
 
+            <label class="detail-note" for="detail-note-input" data-nosnippet>
+              <span class="detail-note-label">Persönliche Anmerkung</span>
+              <textarea
+                id="detail-note-input"
+                rows="3"
+                maxlength="600"
+                placeholder="z. B. gut beleuchtet, enger Parkplatz, Bäckerei um die Ecke"
+              ></textarea>
+              <span id="detail-note-status" class="detail-note-status">Nur auf diesem Gerät gespeichert</span>
+            </label>
+
             <div class="detail-actions">
               <a
                 id="btn-nav-google"
@@ -681,6 +701,6 @@
       crossorigin=""
     ></script>
     <script src="./app-install-promo.js"></script>
-    <script src="./app.js?v=20260503-shared-ratings" type="module"></script>
+    <script src="./app.js?v=20260510-notes-sort" type="module"></script>
   </body>
 </html>

--- a/web/note.mjs
+++ b/web/note.mjs
@@ -1,0 +1,52 @@
+const MAX_NOTE_LENGTH = 600;
+
+export function normalizeNote(value) {
+  const normalized = String(value || "")
+    .replace(/\r\n?/g, "\n")
+    .trim();
+  return normalized.slice(0, MAX_NOTE_LENGTH);
+}
+
+export function parseStoredNotes(raw) {
+  const notes = new Map();
+  if (!raw) {
+    return notes;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return notes;
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return notes;
+  }
+
+  Object.entries(payload).forEach(([stationId, value]) => {
+    const id = String(stationId || "").trim();
+    const note = normalizeNote(value);
+    if (id && note) {
+      notes.set(id, note);
+    }
+  });
+  return notes;
+}
+
+export function serializeStoredNotes(notes) {
+  const entries = Array.from(notes instanceof Map ? notes.entries() : [])
+    .map(([stationId, value]) => [String(stationId || "").trim(), normalizeNote(value)])
+    .filter(([stationId, note]) => stationId && note)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  return JSON.stringify(Object.fromEntries(entries));
+}
+
+export function getUserNote(notes, stationId) {
+  const id = String(stationId || "").trim();
+  if (!id || !(notes instanceof Map)) {
+    return "";
+  }
+  return normalizeNote(notes.get(id));
+}

--- a/web/note.test.mjs
+++ b/web/note.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getUserNote,
+  normalizeNote,
+  parseStoredNotes,
+  serializeStoredNotes,
+} from "./note.mjs";
+
+test("normalizes personal station notes", () => {
+  assert.equal(normalizeNote("  gut erreichbar\r\nnachts hell  "), "gut erreichbar\nnachts hell");
+  assert.equal(normalizeNote(null), "");
+  assert.equal(normalizeNote("x".repeat(700)).length, 600);
+});
+
+test("parses and serializes stored station notes", () => {
+  const notes = parseStoredNotes(JSON.stringify({
+    "station-b": " zweite Notiz ",
+    "station-a": "erste Notiz",
+    "station-empty": "   ",
+  }));
+
+  assert.equal(getUserNote(notes, "station-a"), "erste Notiz");
+  assert.equal(getUserNote(notes, "station-b"), "zweite Notiz");
+  assert.equal(getUserNote(notes, "station-empty"), "");
+  assert.equal(
+    serializeStoredNotes(notes),
+    JSON.stringify({ "station-a": "erste Notiz", "station-b": "zweite Notiz" }),
+  );
+});

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -59,7 +59,7 @@
           oder Crash-SDKs eingesetzt.
         </p>
         <ul>
-          <li>Favoriten werden lokal auf dem jeweiligen Gerät gespeichert.</li>
+          <li>Favoriten, Bewertungen und persönliche Anmerkungen werden lokal auf dem jeweiligen Gerät gespeichert.</li>
           <li>Optional importierte Datenbundles bleiben lokal auf dem Gerät.</li>
           <li>Es werden keine serverseitigen Nutzerprofile angelegt.</li>
         </ul>
@@ -108,9 +108,9 @@
 
         <h2>Speicherdauer</h2>
         <p>
-          Lokal gespeicherte Favoriten und importierte Datenbundles bleiben auf
-          deinem Gerät, bis du sie selbst entfernst oder die Anwendung
-          deinstallierst.
+          Lokal gespeicherte Favoriten, Bewertungen, persönliche Anmerkungen
+          und importierte Datenbundles bleiben auf deinem Gerät, bis du sie
+          selbst entfernst oder die Anwendung deinstallierst.
         </p>
 
         <h2>Kontakt</h2>

--- a/web/styles.css
+++ b/web/styles.css
@@ -114,6 +114,28 @@ body {
   font-weight: 600;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.sort-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.sort-control select {
+  width: auto;
+  min-width: 8.5rem;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.9rem;
+}
+
 /* APP INSTALL PROMO */
 .app-install-promo {
   margin: 0 0 16px;
@@ -449,13 +471,15 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: 0.85rem;
   margin-bottom: 0.5rem;
 }
 
 .card-title-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -471,6 +495,7 @@ body {
   font-size: 1.05rem;
   margin: 0;
   min-width: 0;
+  line-height: 1.22;
 }
 
 .rating-badge {
@@ -489,12 +514,21 @@ body {
   flex-shrink: 0;
 }
 
+.card-metrics {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
 .card-distance {
   background: var(--color-primary-light);
   color: var(--color-primary-dark);
-  padding: 2px 8px;
+  padding: 0.15rem 0.45rem;
   border-radius: 4px;
-  font-size: 0.8rem;
+  font-size: 0.82rem;
+  line-height: 1.2;
   font-weight: 600;
   white-space: nowrap;
 }
@@ -513,6 +547,30 @@ body {
 
 .card-badges:empty {
   display: none;
+}
+
+.card-note {
+  display: grid;
+  gap: 0.25rem;
+  margin-top: 0.8rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.card-note-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+}
+
+.card-note p {
+  margin: 0;
+  color: var(--color-text-main);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .card-badge-line {
@@ -660,7 +718,8 @@ body {
 }
 
 select,
-input[type="search"] {
+input[type="search"],
+textarea {
   width: 100%;
   padding: 0.75rem;
   border: 1px solid var(--color-border);
@@ -669,6 +728,12 @@ input[type="search"] {
   font-size: 1rem;
   background: var(--color-bg);
   color: var(--color-text-main);
+}
+
+textarea {
+  min-height: 96px;
+  resize: vertical;
+  line-height: 1.45;
 }
 
 input[type="range"] {
@@ -933,6 +998,22 @@ input[type="search"]::placeholder {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface-dim);
+}
+
+.detail-note {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+}
+
+.detail-note-label {
+  font-weight: 700;
+  color: var(--color-text-main);
+}
+
+.detail-note-status {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
 }
 
 .detail-rating-copy {
@@ -1530,6 +1611,14 @@ input[type="search"]::placeholder {
 }
 
 @media (max-width: 420px) {
+  .sort-control > span {
+    display: none;
+  }
+
+  .sort-control select {
+    min-width: 7.5rem;
+  }
+
   .occupancy-history-chart {
     padding-inline: 0.65rem;
     overflow-x: auto;


### PR DESCRIPTION
## Änderungen

- Persönliche Anmerkungen für einzelne Ladesäulen hinzugefügt
- Anmerkungen werden lokal im Browser gespeichert, genauso wie Favoriten und eigene Bewertungen
- Anmerkungen werden in der Favoritenansicht direkt unter der jeweiligen Ladesäule angezeigt
- Favoriten können jetzt nach Entfernung oder nach vergebenen Sternen sortiert werden
- Darstellung von Bewertung und Entfernung in den Favoritenkarten überarbeitet
- Datenschutzhinweis ergänzt, da persönliche Anmerkungen lokal gespeichert werden

## Tests

- `node --check web/app.js`
- `node --test web/filtering.test.mjs web/location.test.mjs web/rating.test.mjs web/note.test.mjs`
- `python3 scripts/build_site.py`
- Lokaler Browser-Test mit Favoriten, Notizen und Sortierung